### PR TITLE
Added migration for game-to-console mapping and analytics in 20260604…

### DIFF
--- a/controllers/controllers.py
+++ b/controllers/controllers.py
@@ -1290,6 +1290,35 @@ def get_all_gaming_cafe():
         return jsonify({'message': 'An error occurred while fetching vendor data', 'error': str(e)}), 500
 
 
+@vendor_bp.route('/vendor/gaming-cafes/search', methods=['GET'])
+def search_gaming_cafes():
+    """
+    Lightweight app discovery API.
+    Filters cafes by game, budget, location, and open-now state with cursor pagination.
+    """
+    try:
+        open_now = str(request.args.get("open_now", "")).strip().lower() in {"1", "true", "yes", "y"}
+        response_data = VendorService.search_gaming_cafes(
+            game_id=request.args.get("game_id"),
+            game_name=request.args.get("game_name") or request.args.get("name"),
+            min_price=request.args.get("min_price"),
+            max_price=request.args.get("max_price"),
+            city=request.args.get("city"),
+            pincode=request.args.get("pincode"),
+            lat=request.args.get("lat"),
+            lng=request.args.get("lng"),
+            radius_km=request.args.get("radius_km"),
+            open_now=open_now,
+            limit=request.args.get("limit", 20),
+            cursor=request.args.get("cursor"),
+            sort=request.args.get("sort", "price"),
+        )
+        return jsonify(response_data), 200
+    except Exception as e:
+        current_app.logger.error(f"Error searching gaming cafes: {e}")
+        return jsonify({'message': 'An error occurred while searching gaming cafes', 'error': str(e)}), 500
+
+
 
 
 @vendor_bp.route('/upload-photos/<int:vendor_id>', methods=['POST'])

--- a/controllers/vendor_games.py
+++ b/controllers/vendor_games.py
@@ -19,6 +19,57 @@ def health_check():
         "message": "Games endpoint is working",
         "timestamp": "2025-07-24"
     }), 200
+
+
+@vendor_games_bp.route('/games/platforms', methods=['GET'])
+def list_game_discovery_platforms():
+    try:
+        include_empty = str(request.args.get("include_empty", "")).strip().lower() in {"1", "true", "yes", "y"}
+        return jsonify(GameService.list_discovery_platforms(include_empty=include_empty)), 200
+    except Exception as e:
+        current_app.logger.error(f"Failed to fetch game platforms: {str(e)}")
+        return jsonify({"message": f"Failed to fetch game platforms: {str(e)}"}), 500
+
+
+@vendor_games_bp.route('/games/search', methods=['GET'])
+def search_discovery_games():
+    try:
+        return jsonify(GameService.search_discovery_games(
+            q=request.args.get("q") or request.args.get("search"),
+            console_slug=request.args.get("console_slug") or request.args.get("platform_type"),
+            console_catalog_id=request.args.get("console_catalog_id"),
+            limit=request.args.get("limit", 20),
+            cursor=request.args.get("cursor"),
+        )), 200
+    except Exception as e:
+        current_app.logger.error(f"Failed to search games: {str(e)}")
+        return jsonify({"message": f"Failed to search games: {str(e)}"}), 500
+
+
+@vendor_games_bp.route('/games/popular', methods=['GET'])
+def popular_discovery_games():
+    try:
+        return jsonify(GameService.get_popular_discovery_games(
+            console_slug=request.args.get("console_slug") or request.args.get("platform_type"),
+            console_catalog_id=request.args.get("console_catalog_id"),
+            city=request.args.get("city"),
+            limit=request.args.get("limit", 20),
+        )), 200
+    except Exception as e:
+        current_app.logger.error(f"Failed to fetch popular games: {str(e)}")
+        return jsonify({"message": f"Failed to fetch popular games: {str(e)}"}), 500
+
+
+@vendor_games_bp.route('/games/discovery-events', methods=['POST'])
+def record_game_discovery_event():
+    try:
+        data = request.get_json(silent=True) or {}
+        return jsonify(GameService.record_discovery_event(data)), 201
+    except ValueError as e:
+        return jsonify({"message": str(e)}), 400
+    except Exception as e:
+        current_app.logger.error(f"Failed to record game discovery event: {str(e)}")
+        return jsonify({"message": f"Failed to record game discovery event: {str(e)}"}), 500
          
         # Route 2 (cloudinary configration testing)
 
@@ -306,6 +357,3 @@ def get_all_games():
         }), 200
     except Exception as e:
         return jsonify({"message": f"Failed to fetch games: {str(e)}"}), 500
-    
-    
- 

--- a/services/game_service.py
+++ b/services/game_service.py
@@ -1,10 +1,403 @@
 from models.game import Game
-from db.extensions import db
+from db.extensions import db, redis_client
 from datetime import datetime
 from services.cloudinary_services import CloudinaryGameImageService
 from flask import current_app
+from sqlalchemy import text
+import json
+import os
 
 class GameService:
+    DISCOVERY_CACHE_TTL_SECONDS = int(os.getenv("GAME_DISCOVERY_CACHE_TTL_SECONDS", "300"))
+    POPULAR_EVENT_WEIGHTS = {
+        "booking_success": 10,
+        "booking_start": 6,
+        "result_view": 4,
+        "click": 3,
+        "view": 1,
+        "search": 1,
+    }
+
+    @staticmethod
+    def _normalize_limit(limit, default=20, maximum=50):
+        try:
+            return max(1, min(int(limit or default), maximum))
+        except Exception:
+            return default
+
+    @staticmethod
+    def _normalize_offset(cursor):
+        try:
+            return max(0, int(cursor or 0))
+        except Exception:
+            return 0
+
+    @staticmethod
+    def _safe_int(value):
+        try:
+            if value in (None, ""):
+                return None
+            return int(value)
+        except Exception:
+            return None
+
+    @staticmethod
+    def _safe_float(value, scale=6):
+        try:
+            if value in (None, ""):
+                return None
+            return round(float(value), scale)
+        except Exception:
+            return None
+
+    @staticmethod
+    def _game_card(row):
+        return {
+            "id": row["id"],
+            "slug": row["slug"],
+            "name": row["name"],
+            "genre": row["genre"],
+            "platform": row["platform"],
+            "image_url": row["image_url"],
+            "multiplayer": bool(row["multiplayer"]) if row["multiplayer"] is not None else False,
+            "average_rating": float(row["average_rating"] or 0),
+            "rawg_rating": float(row["rawg_rating"] or 0),
+            "console_catalog": {
+                "id": row["console_catalog_id"],
+                "slug": row["console_slug"],
+                "display_name": row["console_display_name"],
+                "family": row["console_family"],
+                "icon": row["console_icon"],
+            } if row["console_catalog_id"] else None,
+            "popularity_score": float(row["popularity_score"] or 0),
+        }
+
+    @staticmethod
+    def _cache_get(cache_key):
+        try:
+            cached = redis_client.get(cache_key)
+            if cached:
+                return json.loads(cached)
+        except Exception:
+            return None
+        return None
+
+    @staticmethod
+    def _cache_set(cache_key, payload, ttl=None):
+        try:
+            redis_client.setex(cache_key, int(ttl or GameService.DISCOVERY_CACHE_TTL_SECONDS), json.dumps(payload))
+        except Exception:
+            pass
+
+    @staticmethod
+    def list_discovery_platforms(include_empty=False):
+        cache_key = f"games:platforms:v1:{bool(include_empty)}"
+        cached = GameService._cache_get(cache_key)
+        if cached:
+            return cached
+
+        where_clause = "WHERE cc.is_active = true"
+        if not include_empty:
+            where_clause += " AND COALESCE(gc.game_count, 0) > 0"
+        rows = db.session.execute(text(f"""
+            WITH game_counts AS (
+                SELECT console_catalog_id, COUNT(DISTINCT game_id) AS game_count
+                FROM game_console_catalog
+                WHERE is_active = true
+                GROUP BY console_catalog_id
+            )
+            SELECT
+                cc.id,
+                cc.slug,
+                cc.display_name,
+                cc.family,
+                cc.icon,
+                cc.input_mode,
+                cc.supports_multiplayer,
+                cc.default_capacity,
+                cc.controller_policy,
+                COALESCE(gc.game_count, 0) AS game_count
+            FROM console_catalog cc
+            LEFT JOIN game_counts gc ON gc.console_catalog_id = cc.id
+            {where_clause}
+            ORDER BY COALESCE(gc.game_count, 0) DESC, cc.display_name ASC
+        """)).mappings().all()
+
+        payload = {
+            "platforms": [
+                {
+                    "id": row["id"],
+                    "slug": row["slug"],
+                    "display_name": row["display_name"],
+                    "family": row["family"],
+                    "icon": row["icon"],
+                    "input_mode": row["input_mode"],
+                    "supports_multiplayer": bool(row["supports_multiplayer"]),
+                    "default_capacity": row["default_capacity"],
+                    "controller_policy": row["controller_policy"],
+                    "game_count": int(row["game_count"] or 0),
+                }
+                for row in rows
+            ]
+        }
+        GameService._cache_set(cache_key, payload, ttl=600)
+        return payload
+
+    @staticmethod
+    def search_discovery_games(q=None, console_slug=None, console_catalog_id=None, limit=20, cursor=None):
+        limit = GameService._normalize_limit(limit)
+        offset = GameService._normalize_offset(cursor)
+        normalized_query = str(q or "").strip().lower()
+        normalized_console_slug = str(console_slug or "").strip().lower()
+        catalog_id = GameService._safe_int(console_catalog_id)
+
+        cache_payload = {
+            "q": normalized_query,
+            "console_slug": normalized_console_slug,
+            "console_catalog_id": catalog_id,
+            "limit": limit,
+            "offset": offset,
+        }
+        cache_key = f"games:search:v1:{json.dumps(cache_payload, sort_keys=True, separators=(',', ':'))}"
+        cached = GameService._cache_get(cache_key)
+        if cached:
+            return cached
+
+        where = ["gcc.is_active = true", "cc.is_active = true"]
+        params = {
+            "q": normalized_query or None,
+            "console_slug": normalized_console_slug or None,
+            "console_catalog_id": catalog_id,
+            "limit": limit + 1,
+            "offset": offset,
+        }
+        if normalized_query:
+            where.append("(LOWER(g.name) LIKE CONCAT('%', :q, '%') OR LOWER(COALESCE(g.slug, '')) LIKE CONCAT('%', :q, '%'))")
+        if catalog_id is not None:
+            where.append("cc.id = :console_catalog_id")
+        elif normalized_console_slug:
+            where.append("cc.slug = :console_slug")
+
+        rows = db.session.execute(text(f"""
+            SELECT
+                g.id,
+                g.slug,
+                g.name,
+                g.genre,
+                g.platform,
+                g.image_url,
+                g.multiplayer,
+                g.average_rating,
+                g.rawg_rating,
+                cc.id AS console_catalog_id,
+                cc.slug AS console_slug,
+                cc.display_name AS console_display_name,
+                cc.family AS console_family,
+                cc.icon AS console_icon,
+                gcc.popularity_score
+            FROM game_console_catalog gcc
+            JOIN games g ON g.id = gcc.game_id
+            JOIN console_catalog cc ON cc.id = gcc.console_catalog_id
+            WHERE {" AND ".join(where)}
+            ORDER BY gcc.popularity_score DESC, COALESCE(g.average_rating, g.rawg_rating, 0) DESC, g.name ASC
+            LIMIT :limit OFFSET :offset
+        """), params).mappings().all()
+
+        result_rows = rows[:limit]
+        payload = {
+            "games": [GameService._game_card(row) for row in result_rows],
+            "count": len(result_rows),
+            "next_cursor": str(offset + limit) if len(rows) > limit else None,
+            "filters": {
+                "q": normalized_query or None,
+                "console_slug": normalized_console_slug or None,
+                "console_catalog_id": catalog_id,
+                "limit": limit,
+            },
+        }
+        GameService._cache_set(cache_key, payload)
+        return payload
+
+    @staticmethod
+    def get_popular_discovery_games(console_slug=None, console_catalog_id=None, city=None, limit=20):
+        limit = GameService._normalize_limit(limit)
+        normalized_console_slug = str(console_slug or "").strip().lower()
+        normalized_city = str(city or "").strip().lower()
+        catalog_id = GameService._safe_int(console_catalog_id)
+        weights = GameService.POPULAR_EVENT_WEIGHTS
+
+        cache_payload = {
+            "console_slug": normalized_console_slug,
+            "console_catalog_id": catalog_id,
+            "city": normalized_city,
+            "limit": limit,
+        }
+        cache_key = f"games:popular:v1:{json.dumps(cache_payload, sort_keys=True, separators=(',', ':'))}"
+        cached = GameService._cache_get(cache_key)
+        if cached:
+            return cached
+
+        where = ["gcc.is_active = true", "cc.is_active = true"]
+        params = {
+            "console_slug": normalized_console_slug or None,
+            "console_catalog_id": catalog_id,
+            "city": normalized_city or None,
+            "limit": limit,
+            "booking_success_weight": weights["booking_success"],
+            "booking_start_weight": weights["booking_start"],
+            "result_view_weight": weights["result_view"],
+            "click_weight": weights["click"],
+            "view_weight": weights["view"],
+            "search_weight": weights["search"],
+        }
+        if catalog_id is not None:
+            where.append("cc.id = :console_catalog_id")
+        elif normalized_console_slug:
+            where.append("cc.slug = :console_slug")
+
+        rows = db.session.execute(text(f"""
+            WITH event_scores AS (
+                SELECT
+                    game_id,
+                    console_catalog_id,
+                    SUM(CASE event_type
+                        WHEN 'booking_success' THEN :booking_success_weight
+                        WHEN 'booking_start' THEN :booking_start_weight
+                        WHEN 'result_view' THEN :result_view_weight
+                        WHEN 'click' THEN :click_weight
+                        WHEN 'view' THEN :view_weight
+                        WHEN 'search' THEN :search_weight
+                        ELSE 0
+                    END) AS event_score
+                FROM game_discovery_events
+                WHERE created_at >= NOW() - INTERVAL '7 days'
+                  AND game_id IS NOT NULL
+                  AND (:city IS NULL OR LOWER(COALESCE(city, '')) = :city)
+                GROUP BY game_id, console_catalog_id
+            )
+            SELECT
+                g.id,
+                g.slug,
+                g.name,
+                g.genre,
+                g.platform,
+                g.image_url,
+                g.multiplayer,
+                g.average_rating,
+                g.rawg_rating,
+                cc.id AS console_catalog_id,
+                cc.slug AS console_slug,
+                cc.display_name AS console_display_name,
+                cc.family AS console_family,
+                cc.icon AS console_icon,
+                (COALESCE(es.event_score, 0) + COALESCE(gcc.popularity_score, 0)) AS popularity_score
+            FROM game_console_catalog gcc
+            JOIN games g ON g.id = gcc.game_id
+            JOIN console_catalog cc ON cc.id = gcc.console_catalog_id
+            LEFT JOIN event_scores es
+              ON es.game_id = g.id
+             AND es.console_catalog_id = cc.id
+            WHERE {" AND ".join(where)}
+            ORDER BY (COALESCE(es.event_score, 0) + COALESCE(gcc.popularity_score, 0)) DESC,
+                     COALESCE(g.average_rating, g.rawg_rating, 0) DESC,
+                     g.name ASC
+            LIMIT :limit
+        """), params).mappings().all()
+
+        payload = {
+            "games": [GameService._game_card(row) for row in rows],
+            "count": len(rows),
+            "filters": {
+                "console_slug": normalized_console_slug or None,
+                "console_catalog_id": catalog_id,
+                "city": normalized_city or None,
+                "limit": limit,
+            },
+        }
+        GameService._cache_set(cache_key, payload)
+        return payload
+
+    @staticmethod
+    def record_discovery_event(data):
+        event_type = str(data.get("event_type") or "").strip().lower()
+        if event_type not in GameService.POPULAR_EVENT_WEIGHTS:
+            raise ValueError("Invalid event_type")
+
+        game_id = GameService._safe_int(data.get("game_id"))
+        console_catalog_id = GameService._safe_int(data.get("console_catalog_id"))
+        console_slug = str(data.get("console_slug") or data.get("platform_type") or "").strip().lower() or None
+        city = str(data.get("city") or "").strip().lower() or None
+        pincode = str(data.get("pincode") or "").strip() or None
+        search_query = str(data.get("search_query") or data.get("q") or "").strip() or None
+        game_name = str(data.get("game_name") or "").strip() or None
+        metadata = data.get("metadata") if isinstance(data.get("metadata"), dict) else {}
+
+        if game_id and not game_name:
+            game = db.session.get(Game, game_id)
+            game_name = game.name if game else None
+
+        if console_catalog_id is None and console_slug:
+            row = db.session.execute(
+                text("SELECT id FROM console_catalog WHERE slug = :slug"),
+                {"slug": console_slug},
+            ).mappings().first()
+            console_catalog_id = row["id"] if row else None
+
+        db.session.execute(text("""
+            INSERT INTO game_discovery_events (
+                user_id,
+                session_id,
+                game_id,
+                game_name,
+                console_catalog_id,
+                console_slug,
+                city,
+                pincode,
+                lat,
+                lng,
+                event_type,
+                search_query,
+                metadata
+            )
+            VALUES (
+                :user_id,
+                :session_id,
+                :game_id,
+                :game_name,
+                :console_catalog_id,
+                :console_slug,
+                :city,
+                :pincode,
+                :lat,
+                :lng,
+                :event_type,
+                :search_query,
+                CAST(:metadata AS jsonb)
+            )
+        """), {
+            "user_id": GameService._safe_int(data.get("user_id")),
+            "session_id": str(data.get("session_id") or "")[:128] or None,
+            "game_id": game_id,
+            "game_name": game_name,
+            "console_catalog_id": console_catalog_id,
+            "console_slug": console_slug,
+            "city": city,
+            "pincode": pincode,
+            "lat": GameService._safe_float(data.get("lat")),
+            "lng": GameService._safe_float(data.get("lng")),
+            "event_type": event_type,
+            "search_query": search_query,
+            "metadata": json.dumps(metadata),
+        })
+        db.session.commit()
+
+        return {
+            "success": True,
+            "event_type": event_type,
+            "game_id": game_id,
+            "console_catalog_id": console_catalog_id,
+        }
+
     @staticmethod
     def create_game(
         name,
@@ -118,6 +511,3 @@ class GameService:
             multiplayer=multiplayer,
             esrb_rating=esrb_rating,
         )
-
-    
-  

--- a/services/services.py
+++ b/services/services.py
@@ -2,6 +2,8 @@
 
 import os
 import re  # ✅ ADDED for PIN validation
+import base64
+import json
 from werkzeug.security import generate_password_hash
 from werkzeug.utils import secure_filename
 from flask import current_app
@@ -34,7 +36,7 @@ from models.transaction import Transaction
 from models.paymentMethod import PaymentMethod
 from models.paymentVendorMap import PaymentVendorMap
 from sqlalchemy import exists
-from db.extensions import db
+from db.extensions import db, redis_client
 from .utils import send_email, generate_credentials, generate_unique_vendor_pin
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseUpload
@@ -1339,6 +1341,413 @@ class VendorService:
         except Exception as e:
             current_app.logger.error(f"Error in get_all_gaming_cafe: {e}")
             raise
+
+    @staticmethod
+    def _encode_search_cursor(value, vendor_id, sort="price"):
+        payload = {"value": float(value or 0), "vendor_id": int(vendor_id), "sort": str(sort or "price")}
+        raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).decode("utf-8").rstrip("=")
+
+    @staticmethod
+    def _decode_search_cursor(cursor):
+        if not cursor:
+            return None
+        try:
+            padded = str(cursor) + ("=" * (-len(str(cursor)) % 4))
+            payload = json.loads(base64.urlsafe_b64decode(padded.encode("utf-8")).decode("utf-8"))
+            return {
+                "value": float(payload.get("value", payload.get("price", 0))),
+                "vendor_id": int(payload.get("vendor_id", 0)),
+                "sort": str(payload.get("sort", "price")),
+            }
+        except Exception:
+            return None
+
+    @staticmethod
+    def search_gaming_cafes(
+        game_id=None,
+        game_name=None,
+        min_price=None,
+        max_price=None,
+        city=None,
+        pincode=None,
+        lat=None,
+        lng=None,
+        radius_km=None,
+        open_now=False,
+        limit=20,
+        cursor=None,
+        sort="price",
+    ):
+        """
+        Lightweight app discovery search for cafes offering a game.
+        Designed for high read volume: indexed filters, cursor pagination, and short Redis cache.
+        """
+        try:
+            limit = max(1, min(int(limit or 20), 50))
+        except Exception:
+            limit = 20
+
+        allowed_sorts = {"distance", "price", "rating", "popular"}
+        requested_sort = str(sort or "price").strip().lower()
+        if requested_sort not in allowed_sorts:
+            requested_sort = "price"
+
+        resolved_game_name = None
+        if game_id:
+            try:
+                game = db.session.get(Game, int(game_id))
+                resolved_game_name = game.name if game else None
+            except Exception:
+                resolved_game_name = None
+
+        normalized_game_name = str(game_name or resolved_game_name or "").strip().lower()
+        normalized_city = str(city or "").strip().lower()
+        normalized_pincode = str(pincode or "").strip()
+
+        cursor_data = VendorService._decode_search_cursor(cursor)
+        try:
+            min_price_value = float(min_price) if min_price not in (None, "") else None
+        except Exception:
+            min_price_value = None
+        try:
+            max_price_value = float(max_price) if max_price not in (None, "") else None
+        except Exception:
+            max_price_value = None
+
+        try:
+            lat_value = float(lat) if lat not in (None, "") else None
+            lng_value = float(lng) if lng not in (None, "") else None
+            radius_value = float(radius_km) if radius_km not in (None, "") else None
+        except Exception:
+            lat_value = lng_value = radius_value = None
+
+        if requested_sort == "distance" and (lat_value is None or lng_value is None):
+            requested_sort = "price"
+
+        cache_payload = {
+            "game_id": int(game_id) if str(game_id or "").isdigit() else None,
+            "game_name": normalized_game_name,
+            "min_price": min_price_value,
+            "max_price": max_price_value,
+            "city": normalized_city,
+            "pincode": normalized_pincode,
+            "lat": round(lat_value, 4) if lat_value is not None else None,
+            "lng": round(lng_value, 4) if lng_value is not None else None,
+            "radius_km": radius_value,
+            "open_now": bool(open_now),
+            "limit": limit,
+            "sort": requested_sort,
+            "cursor": cursor_data,
+        }
+        cache_key = f"cafe_search:v1:{json.dumps(cache_payload, sort_keys=True, separators=(',', ':'))}"
+        try:
+            cached = redis_client.get(cache_key)
+            if cached:
+                return json.loads(cached)
+        except Exception:
+            cached = None
+
+        ist = ZoneInfo("Asia/Kolkata")
+        now = datetime.now(ist)
+        current_day = now.strftime("%A").lower()
+        current_day_short = now.strftime("%a").lower()
+        current_time = now.strftime("%H:%M:%S")
+
+        where = [
+            "LOWER(COALESCE(ls.status, 'pending_verification')) = 'active'",
+        ]
+        params = {
+            "limit": limit + 1,
+            "current_day": current_day,
+            "current_day_short": current_day_short,
+            "current_time": current_time,
+            "game_id": int(game_id) if str(game_id or "").isdigit() else None,
+            "game_name": normalized_game_name or None,
+            "min_price": min_price_value,
+            "max_price": max_price_value,
+            "city": normalized_city or None,
+            "pincode": normalized_pincode or None,
+            "lat": lat_value,
+            "lng": lng_value,
+            "radius_km": radius_value,
+            "cursor_value": cursor_data["value"] if cursor_data and cursor_data.get("sort") == requested_sort else None,
+            "cursor_vendor_id": cursor_data["vendor_id"] if cursor_data else None,
+            "current_date": now.date(),
+        }
+
+        if params["game_id"] is not None:
+            where.append("""(
+                (
+                    vgm.vendor_id IS NOT NULL
+                    AND (
+                        :game_name IS NULL
+                        OR LOWER(ag.game_name) = :game_name
+                        OR LOWER(ag.game_name) LIKE CONCAT('%', :game_name, '%')
+                    )
+                )
+                OR (:game_name IS NOT NULL AND LOWER(ag.game_name) = :game_name)
+            )""")
+        elif params["game_name"]:
+            where.append("LOWER(ag.game_name) LIKE CONCAT('%', :game_name, '%')")
+        if min_price_value is not None:
+            where.append("COALESCE(ao.offered_price, ag.single_slot_price) >= :min_price")
+        if max_price_value is not None:
+            where.append("COALESCE(ao.offered_price, ag.single_slot_price) <= :max_price")
+        if normalized_city:
+            where.append("""(
+                LOWER(COALESCE(pa.addressLine2, '')) LIKE CONCAT('%', :city, '%')
+                OR LOWER(COALESCE(pa.addressLine1, '')) LIKE CONCAT('%', :city, '%')
+                OR LOWER(COALESCE(pa.state, '')) LIKE CONCAT('%', :city, '%')
+            )""")
+        if normalized_pincode:
+            where.append("pa.pincode = :pincode")
+
+        distance_sql = "NULL::double precision"
+        if lat_value is not None and lng_value is not None:
+            distance_sql = """
+                CASE
+                    WHEN pa.latitude ~ '^-?[0-9]+(\\.[0-9]+)?$'
+                     AND pa.longitude ~ '^-?[0-9]+(\\.[0-9]+)?$'
+                    THEN (
+                        6371 * acos(
+                            LEAST(1, GREATEST(-1,
+                                cos(radians(:lat)) * cos(radians(CAST(pa.latitude AS double precision))) *
+                                cos(radians(CAST(pa.longitude AS double precision)) - radians(:lng)) +
+                                sin(radians(:lat)) * sin(radians(CAST(pa.latitude AS double precision)))
+                            ))
+                        )
+                    )
+                    ELSE NULL
+                END
+            """
+            if radius_value is not None and radius_value > 0:
+                where.append(f"({distance_sql}) <= :radius_km")
+
+        sort_value_sql = "COALESCE(ao.offered_price, ag.single_slot_price)::double precision"
+        order_sql = "effective_price ASC, v.id ASC"
+        cursor_operator = ">"
+        if requested_sort == "distance":
+            sort_value_sql = f"COALESCE(({distance_sql}), 999999)::double precision"
+            order_sql = "distance_sort_value ASC, v.id ASC"
+        elif requested_sort == "rating":
+            sort_value_sql = "COALESCE(vgm.game_rating, 0)::double precision"
+            order_sql = "sort_value DESC, v.id ASC"
+            cursor_operator = "<"
+        elif requested_sort == "popular":
+            sort_value_sql = "COALESCE(ag.total_slot, 0)::double precision"
+            order_sql = "sort_value DESC, v.id ASC"
+            cursor_operator = "<"
+
+        if params["cursor_value"] is not None:
+            if cursor_operator == "<":
+                where.append(f"(({sort_value_sql}) < :cursor_value OR (({sort_value_sql}) = :cursor_value AND v.id > :cursor_vendor_id))")
+            else:
+                where.append(f"(({sort_value_sql}) > :cursor_value OR (({sort_value_sql}) = :cursor_value AND v.id > :cursor_vendor_id))")
+
+        is_open_sql = """
+            CASE
+                WHEN COALESCE(vdsc.opening_time, t.opening_time) IS NULL
+                  OR COALESCE(vdsc.closing_time, t.closing_time) IS NULL
+                THEN false
+                WHEN COALESCE(vdsc.opening_time, t.opening_time)::time = COALESCE(vdsc.closing_time, t.closing_time)::time
+                THEN true
+                WHEN COALESCE(vdsc.opening_time, t.opening_time)::time < COALESCE(vdsc.closing_time, t.closing_time)::time
+                THEN :current_time::time BETWEEN COALESCE(vdsc.opening_time, t.opening_time)::time AND COALESCE(vdsc.closing_time, t.closing_time)::time
+                ELSE :current_time::time >= COALESCE(vdsc.opening_time, t.opening_time)::time
+                  OR :current_time::time <= COALESCE(vdsc.closing_time, t.closing_time)::time
+            END
+        """
+        if open_now:
+            where.append(f"({is_open_sql}) = true")
+
+        sql = text(f"""
+            WITH latest_status_ts AS (
+                SELECT vendor_id, MAX(updated_at) AS updated_at
+                FROM vendor_statuses
+                GROUP BY vendor_id
+            ),
+            latest_status AS (
+                SELECT vs.vendor_id, vs.status
+                FROM vendor_statuses vs
+                JOIN latest_status_ts lst
+                  ON lst.vendor_id = vs.vendor_id
+                 AND lst.updated_at = vs.updated_at
+            ),
+            vendor_game_match AS (
+                SELECT
+                    vg.vendor_id,
+                    vg.game_id,
+                    MAX(g.name) AS game_name,
+                    MAX(COALESCE(g.average_rating, g.rawg_rating, 0)) AS game_rating
+                FROM vendor_games vg
+                JOIN games g ON g.id = vg.game_id
+                WHERE :game_id IS NOT NULL
+                  AND vg.game_id = :game_id
+                  AND COALESCE(vg.is_available, true) = true
+                GROUP BY vg.vendor_id, vg.game_id
+            ),
+            image_ranked AS (
+                SELECT
+                    vendor_id,
+                    COALESCE(url, path) AS image_url,
+                    ROW_NUMBER() OVER (PARTITION BY vendor_id ORDER BY id ASC) AS image_rank
+                FROM images
+                WHERE COALESCE(url, path) IS NOT NULL
+            ),
+            image_gallery AS (
+                SELECT
+                    vendor_id,
+                    ARRAY_AGG(image_url ORDER BY image_rank) AS image_urls
+                FROM image_ranked
+                WHERE image_rank <= 3
+                GROUP BY vendor_id
+            ),
+            active_offer AS (
+                SELECT DISTINCT ON (available_game_id)
+                    available_game_id,
+                    offered_price
+                FROM console_pricing_offers
+                WHERE is_active = true
+                  AND start_date <= :current_date
+                  AND end_date >= :current_date
+                  AND (
+                    (start_date = end_date AND :current_time::time BETWEEN start_time AND end_time)
+                    OR (start_date < end_date AND (
+                        (start_date = :current_date AND :current_time::time >= start_time)
+                        OR (end_date = :current_date AND :current_time::time <= end_time)
+                        OR (:current_date > start_date AND :current_date < end_date)
+                    ))
+                  )
+                ORDER BY available_game_id, offered_price ASC
+            )
+            SELECT
+                v.id AS vendor_id,
+                v.cafe_name,
+                ls.status,
+                ci.phone,
+                pa.addressLine1,
+                pa.addressLine2,
+                pa.pincode,
+                pa.state,
+                pa.country,
+                pa.latitude,
+                pa.longitude,
+                ag.id AS available_game_id,
+                ag.game_name,
+                vgm.game_id AS normalized_game_id,
+                vgm.game_name AS normalized_game_name,
+                COALESCE(vgm.game_rating, 0) AS game_rating,
+                ag.total_slot,
+                ag.single_slot_price,
+                ao.offered_price,
+                COALESCE(ao.offered_price, ag.single_slot_price) AS effective_price,
+                ig.image_urls,
+                COALESCE(vdsc.opening_time, t.opening_time) AS opening_time,
+                COALESCE(vdsc.closing_time, t.closing_time) AS closing_time,
+                {is_open_sql} AS is_open_now,
+                {distance_sql} AS distance_km,
+                {sort_value_sql} AS sort_value,
+                {sort_value_sql} AS distance_sort_value
+            FROM available_games ag
+            JOIN vendors v ON v.id = ag.vendor_id
+            LEFT JOIN latest_status ls ON ls.vendor_id = v.id
+            LEFT JOIN vendor_game_match vgm ON vgm.vendor_id = v.id
+            JOIN timing t ON t.id = v.timing_id
+            LEFT JOIN vendor_day_slot_config vdsc
+              ON vdsc.vendor_id = v.id
+             AND LOWER(vdsc.day) IN (:current_day, :current_day_short)
+            LEFT JOIN contact_info ci
+              ON ci.parent_id = v.id
+             AND ci.parent_type = 'vendor'
+            LEFT JOIN physical_address pa
+              ON pa.parent_id = v.id
+             AND pa.parent_type = 'vendor'
+             AND pa.is_active = true
+            LEFT JOIN image_gallery ig
+              ON ig.vendor_id = v.id
+            LEFT JOIN active_offer ao
+              ON ao.available_game_id = ag.id
+            WHERE {" AND ".join(where)}
+            ORDER BY {order_sql}
+            LIMIT :limit
+        """)
+
+        rows = db.session.execute(sql, params).mappings().all()
+        rows_for_response = rows[:limit]
+        vendor_ids = [row["vendor_id"] for row in rows_for_response]
+        payment_methods_map = VendorService.get_payment_methods_for_vendors(vendor_ids) if vendor_ids else {}
+
+        cafes = []
+        for row in rows_for_response:
+            payment_methods = payment_methods_map.get(row["vendor_id"], {})
+            cafes.append({
+                "vendor_id": row["vendor_id"],
+                "cafe_name": row["cafe_name"],
+                "status": row["status"],
+                "phone": row["phone"],
+                "address": {
+                    "addressLine1": row["addressline1"],
+                    "addressLine2": row["addressline2"],
+                    "pincode": row["pincode"],
+                    "state": row["state"],
+                    "country": row["country"],
+                    "latitude": row["latitude"],
+                    "longitude": row["longitude"],
+                },
+                "matched_game": {
+                    "available_game_id": row["available_game_id"],
+                    "game_id": row["normalized_game_id"],
+                    "game_name": row["game_name"],
+                    "normalized_game_name": row["normalized_game_name"],
+                    "total_slot": row["total_slot"],
+                    "price": float(row["effective_price"] or 0),
+                    "currency": "INR",
+                },
+                "starting_price": float(row["single_slot_price"] or 0),
+                "offer_price": float(row["offered_price"]) if row["offered_price"] is not None else None,
+                "images": list(row["image_urls"] or []),
+                "primary_image_url": (row["image_urls"] or [None])[0],
+                "opening_time": str(row["opening_time"]) if row["opening_time"] else None,
+                "closing_time": str(row["closing_time"]) if row["closing_time"] else None,
+                "is_open_now": bool(row["is_open_now"]),
+                "distance_km": round(float(row["distance_km"]), 2) if row["distance_km"] is not None else None,
+                "accepted_payment_methods": {
+                    "pay_in_cafe": bool(payment_methods.get("pay_in_cafe")),
+                    "hash_global_pass": bool(payment_methods.get("hash_global_pass")),
+                    "cafe_specific_pass": bool(payment_methods.get("cafe_specific_pass")),
+                },
+            })
+
+        next_cursor = None
+        if len(rows) > limit and rows_for_response:
+            last = rows_for_response[-1]
+            next_cursor = VendorService._encode_search_cursor(last["sort_value"], last["vendor_id"], requested_sort)
+
+        response = {
+            "cafes": cafes,
+            "count": len(cafes),
+            "next_cursor": next_cursor,
+            "filters": {
+                "game_id": params["game_id"],
+                "game_name": normalized_game_name or None,
+                "min_price": min_price_value,
+                "max_price": max_price_value,
+                "city": normalized_city or None,
+                "pincode": normalized_pincode or None,
+                "lat": lat_value,
+                "lng": lng_value,
+                "radius_km": radius_value,
+                "open_now": bool(open_now),
+                "limit": limit,
+                "sort": requested_sort,
+            },
+        }
+        try:
+            redis_client.setex(cache_key, int(os.getenv("CAFE_SEARCH_CACHE_TTL_SECONDS", "60")), json.dumps(response))
+        except Exception:
+            pass
+        return response
 
 
     @staticmethod

--- a/sql/20260604_game_discovery_catalog.sql
+++ b/sql/20260604_game_discovery_catalog.sql
@@ -1,0 +1,88 @@
+CREATE TABLE IF NOT EXISTS game_console_catalog (
+    id BIGSERIAL PRIMARY KEY,
+    game_id INTEGER NOT NULL REFERENCES games(id) ON DELETE CASCADE,
+    console_catalog_id INTEGER NOT NULL REFERENCES console_catalog(id) ON DELETE CASCADE,
+    source_platform VARCHAR(255),
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    popularity_score NUMERIC(12, 2) NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_game_console_catalog_game_catalog UNIQUE (game_id, console_catalog_id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_game_console_catalog_catalog_active_score
+    ON game_console_catalog (console_catalog_id, is_active, popularity_score DESC, game_id);
+
+CREATE INDEX IF NOT EXISTS ix_game_console_catalog_game_active
+    ON game_console_catalog (game_id, is_active);
+
+CREATE INDEX IF NOT EXISTS ix_games_name_trgm_fallback
+    ON games (LOWER(name));
+
+INSERT INTO game_console_catalog (game_id, console_catalog_id, source_platform)
+SELECT DISTINCT
+    g.id,
+    cc.id,
+    g.platform
+FROM games g
+JOIN console_catalog cc
+  ON cc.slug = CASE
+    WHEN LOWER(g.platform) IN ('pc', 'linux', 'macos', 'web', 'classic macintosh') THEN 'pc'
+    WHEN LOWER(g.platform) IN ('playstation 5', 'playstation 4', 'playstation 3', 'playstation 2', 'ps vita') THEN 'playstation'
+    WHEN LOWER(g.platform) IN ('xbox', 'xbox one', 'xbox 360', 'xbox series s/x') THEN 'xbox'
+    WHEN LOWER(g.platform) = 'nintendo switch' THEN 'nintendo_switch'
+    ELSE NULL
+  END
+WHERE g.platform IS NOT NULL
+  AND cc.is_active = true
+ON CONFLICT (game_id, console_catalog_id) DO UPDATE
+SET source_platform = EXCLUDED.source_platform,
+    is_active = true,
+    updated_at = NOW();
+
+CREATE TABLE IF NOT EXISTS game_discovery_events (
+    id BIGSERIAL PRIMARY KEY,
+    user_id INTEGER,
+    session_id VARCHAR(128),
+    game_id INTEGER REFERENCES games(id) ON DELETE SET NULL,
+    game_name VARCHAR(255),
+    console_catalog_id INTEGER REFERENCES console_catalog(id) ON DELETE SET NULL,
+    console_slug VARCHAR(100),
+    city VARCHAR(100),
+    pincode VARCHAR(10),
+    lat NUMERIC(9, 6),
+    lng NUMERIC(9, 6),
+    event_type VARCHAR(32) NOT NULL,
+    search_query VARCHAR(255),
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT ck_game_discovery_event_type
+        CHECK (event_type IN ('view', 'click', 'search', 'result_view', 'booking_start', 'booking_success'))
+);
+
+CREATE INDEX IF NOT EXISTS ix_game_discovery_events_recent_game
+    ON game_discovery_events (game_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS ix_game_discovery_events_catalog_city_recent
+    ON game_discovery_events (console_catalog_id, city, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS ix_game_discovery_events_type_recent
+    ON game_discovery_events (event_type, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS game_popularity_rankings (
+    id BIGSERIAL PRIMARY KEY,
+    game_id INTEGER NOT NULL REFERENCES games(id) ON DELETE CASCADE,
+    console_catalog_id INTEGER NOT NULL REFERENCES console_catalog(id) ON DELETE CASCADE,
+    city VARCHAR(100) NOT NULL DEFAULT '',
+    score_24h NUMERIC(14, 2) NOT NULL DEFAULT 0,
+    score_7d NUMERIC(14, 2) NOT NULL DEFAULT 0,
+    clicks_count INTEGER NOT NULL DEFAULT 0,
+    searches_count INTEGER NOT NULL DEFAULT 0,
+    result_views_count INTEGER NOT NULL DEFAULT 0,
+    bookings_count INTEGER NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_game_popularity_rankings_scope UNIQUE (game_id, console_catalog_id, city)
+);
+
+CREATE INDEX IF NOT EXISTS ix_game_popularity_rankings_scope_score
+    ON game_popularity_rankings (console_catalog_id, city, score_7d DESC, score_24h DESC);

--- a/sql/20260604_gaming_cafe_search_indexes.sql
+++ b/sql/20260604_gaming_cafe_search_indexes.sql
@@ -1,0 +1,20 @@
+CREATE INDEX IF NOT EXISTS ix_available_games_game_name_lower
+    ON available_games (LOWER(game_name));
+
+CREATE INDEX IF NOT EXISTS ix_available_games_vendor_id
+    ON available_games (vendor_id);
+
+CREATE INDEX IF NOT EXISTS ix_available_games_single_slot_price
+    ON available_games (single_slot_price);
+
+CREATE INDEX IF NOT EXISTS ix_vendor_games_game_vendor_available
+    ON vendor_games (game_id, vendor_id, is_available);
+
+CREATE INDEX IF NOT EXISTS ix_physical_address_pincode_state_active
+    ON physical_address (pincode, state, is_active);
+
+CREATE INDEX IF NOT EXISTS ix_images_vendor_id_id
+    ON images (vendor_id, id);
+
+CREATE INDEX IF NOT EXISTS ix_console_pricing_offers_active_lookup
+    ON console_pricing_offers (available_game_id, is_active, start_date, end_date, offered_price);


### PR DESCRIPTION
…_game_discovery_catalog.sql (line 1).

Added app game APIs in vendor_games.py (line 24):GET /api/games/platforms GET /api/games/popular?console_slug=pc&city=Hyderabad GET /api/games/search?console_slug=pc&q=valorant
POST /api/games/discovery-events

Added cached discovery/query logic in game_service.py (line 10). Kept existing /api/games untouched for legacy/admin use. Documented the app flow in frontend-api.md (line 138). Migration Notes
Maps PC/Linux/macOS/Web/Classic Macintosh -> pc
Maps PlayStation 2/3/4/5/PS Vita -> playstation
Maps Xbox/Xbox One/Xbox 360/Xbox Series S/X -> xbox Maps Nintendo Switch -> nintendo_switch
Leaves Android/iOS/Dreamcast/SEGA/GameCube/Wii U/Nintendo DS unmapped for now because your console_catalog has no matching active category.